### PR TITLE
Adding the Story Type vocabulary and terms

### DIFF
--- a/config/core.entity_form_display.taxonomy_term.story_type.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.story_type.default.yml
@@ -1,0 +1,22 @@
+uuid: 3eac63aa-c9ce-48f2-bc69-95656c39b6a0
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.story_type
+id: taxonomy_term.story_type.default
+targetEntityType: taxonomy_term
+bundle: story_type
+mode: default
+content:
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  description: true
+  path: true

--- a/config/taxonomy.vocabulary.story_type.yml
+++ b/config/taxonomy.vocabulary.story_type.yml
@@ -1,0 +1,8 @@
+uuid: dddb395a-28d4-4586-b9c6-4e531b511e9f
+langcode: en
+status: true
+dependencies: {  }
+name: 'Story Type'
+vid: story_type
+description: ''
+weight: 0

--- a/web/modules/custom/roosevelt_custom/content/taxonomy_term/19.json
+++ b/web/modules/custom/roosevelt_custom/content/taxonomy_term/19.json
@@ -1,0 +1,86 @@
+{
+    "_links": {
+        "self": {
+            "href": "http:\/\/rooseveltedu.docksal\/taxonomy\/term\/19?_format=hal_json"
+        },
+        "type": {
+            "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/story_type"
+        }
+    },
+    "tid": [
+        {
+            "value": 19
+        }
+    ],
+    "uuid": [
+        {
+            "value": "f9146f18-b5d6-4281-afb8-76bd38c742bd"
+        }
+    ],
+    "revision_id": [
+        {
+            "value": 19
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en",
+            "lang": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "story_type"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-11-22T18:07:26+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "status": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "name": [
+        {
+            "value": "News",
+            "lang": "en"
+        }
+    ],
+    "weight": [
+        {
+            "value": 0
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-22T18:07:26+00:00",
+            "lang": "en",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "lang": "en"
+        }
+    ]
+}

--- a/web/modules/custom/roosevelt_custom/content/taxonomy_term/20.json
+++ b/web/modules/custom/roosevelt_custom/content/taxonomy_term/20.json
@@ -1,0 +1,86 @@
+{
+    "_links": {
+        "self": {
+            "href": "http:\/\/rooseveltedu.docksal\/taxonomy\/term\/20?_format=hal_json"
+        },
+        "type": {
+            "href": "http:\/\/drupal.org\/rest\/type\/taxonomy_term\/story_type"
+        }
+    },
+    "tid": [
+        {
+            "value": 20
+        }
+    ],
+    "uuid": [
+        {
+            "value": "1da52dad-524d-46a1-b78e-82e018903355"
+        }
+    ],
+    "revision_id": [
+        {
+            "value": 20
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en",
+            "lang": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "story_type"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-11-22T18:07:26+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "status": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "name": [
+        {
+            "value": "Evergreen feature",
+            "lang": "en"
+        }
+    ],
+    "weight": [
+        {
+            "value": 0
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-22T18:07:26+00:00",
+            "lang": "en",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true,
+            "lang": "en"
+        }
+    ],
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "lang": "en"
+        }
+    ]
+}


### PR DESCRIPTION
## Description
Vocabulary - Story Type


## Related Tickets

* [25888340: Vocabulary - Story Type](https://kanopi.teamwork.com/#/tasks/25888340)


## Steps to Validate

Once this Pull Request has been merged the DEV environment will be rebuilt.

1. Navigation to the [Synchronize](http://dev-rooseveltedu.pantheonsite.io/admin/config/development/configuration) page and import any new configurations. This shouldn't be needed but it is good to double-check.

1. Navigate to the [Taxonomy](http://dev-rooseveltedu.pantheonsite.io/admin/structure/taxonomy) page and verify the Vocabulary exists.

1. View the Vocabulary's term list to verify all terms exist based on [bluepinrt](https://docs.google.com/spreadsheets/d/1F6Y8rOghRSQqAGEcleseYnzEosZ01MN43eSndj--PWg/edit#gid=1448016670)



**New dependencies**:

- `Roosevelt Custom Module` : Custom module created to add functionality to the website

- `Default Content` Module : Default content gives the module and install profile a way to import default content as well as configuration.
