### PR TITLE
adding all paragraphs as fields to all content types.

### DIFF
--- a/config/sync/core.entity_form_display.node.event.default.yml
+++ b/config/sync/core.entity_form_display.node.event.default.yml
@@ -5,9 +5,12 @@ dependencies:
   config:
     - field.field.node.event.accountability_notes
     - field.field.node.event.body
+    - field.field.node.event.field_accordion
     - field.field.node.event.field_affiliated_personnel
     - field.field.node.event.field_audience
+    - field.field.node.event.field_basic_content
     - field.field.node.event.field_brand_pillars
+    - field.field.node.event.field_call_to_action
     - field.field.node.event.field_campus
     - field.field.node.event.field_contact_person
     - field.field.node.event.field_end_date
@@ -33,6 +36,7 @@ dependencies:
   module:
     - content_moderation
     - datetime
+    - entity_reference_revisions
     - field_group
     - link
     - paragraphs
@@ -117,6 +121,15 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_accordion:
+    weight: 27
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_autocomplete
+    region: content
   field_affiliated_personnel:
     weight: 14
     settings:
@@ -135,6 +148,15 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  field_basic_content:
+    weight: 28
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_autocomplete
+    region: content
   field_brand_pillars:
     weight: 15
     settings:
@@ -143,6 +165,15 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: entity_reference_autocomplete
+    region: content
+  field_call_to_action:
+    weight: 29
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_autocomplete
     region: content
   field_campus:
     weight: 15

--- a/config/sync/core.entity_form_display.node.general_info.default.yml
+++ b/config/sync/core.entity_form_display.node.general_info.default.yml
@@ -5,7 +5,10 @@ dependencies:
   config:
     - field.field.node.general_info.accountability_notes
     - field.field.node.general_info.body
+    - field.field.node.general_info.field_accordion
+    - field.field.node.general_info.field_basic_content
     - field.field.node.general_info.field_brand_pillars
+    - field.field.node.general_info.field_call_to_action
     - field.field.node.general_info.field_campus
     - field.field.node.general_info.field_featured_image
     - field.field.node.general_info.field_member_accountability
@@ -15,6 +18,7 @@ dependencies:
     - workflows.workflow.general_info_workflow
   module:
     - content_moderation
+    - entity_reference_revisions
     - field_group
     - paragraphs
     - path
@@ -94,6 +98,24 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_accordion:
+    weight: 28
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_autocomplete
+    region: content
+  field_basic_content:
+    weight: 29
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_autocomplete
+    region: content
   field_brand_pillars:
     weight: 26
     settings:
@@ -102,6 +124,15 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: entity_reference_autocomplete
+    region: content
+  field_call_to_action:
+    weight: 30
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_autocomplete
     region: content
   field_campus:
     weight: 27

--- a/config/sync/core.entity_form_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_form_display.node.landing_page.default.yml
@@ -5,6 +5,9 @@ dependencies:
   config:
     - field.field.node.landing_page.accountability_notes
     - field.field.node.landing_page.body
+    - field.field.node.landing_page.field_accordion
+    - field.field.node.landing_page.field_basic_content
+    - field.field.node.landing_page.field_call_to_action
     - field.field.node.landing_page.field_contact_person
     - field.field.node.landing_page.field_featured_image
     - field.field.node.landing_page.field_member_accountability
@@ -79,6 +82,42 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_accordion:
+    type: entity_reference_paragraphs
+    weight: 27
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+    third_party_settings: {  }
+    region: content
+  field_basic_content:
+    type: entity_reference_paragraphs
+    weight: 26
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+    third_party_settings: {  }
+    region: content
+  field_call_to_action:
+    type: entity_reference_paragraphs
+    weight: 28
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+    third_party_settings: {  }
+    region: content
   field_contact_person:
     type: entity_reference_autocomplete
     weight: 3

--- a/config/sync/core.entity_form_display.node.program.default.yml
+++ b/config/sync/core.entity_form_display.node.program.default.yml
@@ -6,6 +6,9 @@ dependencies:
     - field.field.node.program.accountability_notes
     - field.field.node.program.admission_info
     - field.field.node.program.body
+    - field.field.node.program.field_accordion
+    - field.field.node.program.field_basic_content
+    - field.field.node.program.field_call_to_action
     - field.field.node.program.field_contact_person
     - field.field.node.program.field_location
     - field.field.node.program.field_member_accountability
@@ -21,6 +24,7 @@ dependencies:
     - workflows.workflow.program_workflow
   module:
     - content_moderation
+    - entity_reference_revisions
     - field_group
     - paragraphs
     - path
@@ -94,6 +98,33 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_accordion:
+    weight: 26
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_autocomplete
+    region: content
+  field_basic_content:
+    weight: 27
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_autocomplete
+    region: content
+  field_call_to_action:
+    weight: 28
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_autocomplete
+    region: content
   field_contact_person:
     type: entity_reference_autocomplete
     weight: 6

--- a/config/sync/core.entity_form_display.node.story.default.yml
+++ b/config/sync/core.entity_form_display.node.story.default.yml
@@ -4,8 +4,11 @@ status: true
 dependencies:
   config:
     - field.field.node.story.body
+    - field.field.node.story.field_accordion
     - field.field.node.story.field_accountability_notes
+    - field.field.node.story.field_basic_content
     - field.field.node.story.field_brand_pillars
+    - field.field.node.story.field_call_to_action
     - field.field.node.story.field_campus
     - field.field.node.story.field_date_published
     - field.field.node.story.field_featured
@@ -23,6 +26,7 @@ dependencies:
   module:
     - content_moderation
     - datetime
+    - entity_reference_revisions
     - field_group
     - paragraphs
     - path
@@ -97,6 +101,15 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_accordion:
+    weight: 26
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_autocomplete
+    region: content
   field_accountability_notes:
     weight: 12
     settings:
@@ -104,6 +117,15 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textarea
+    region: content
+  field_basic_content:
+    weight: 27
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_autocomplete
     region: content
   field_brand_pillars:
     weight: 21
@@ -113,6 +135,15 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: entity_reference_autocomplete
+    region: content
+  field_call_to_action:
+    weight: 28
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_autocomplete
     region: content
   field_campus:
     weight: 22

--- a/config/sync/core.entity_view_display.node.event.default.yml
+++ b/config/sync/core.entity_view_display.node.event.default.yml
@@ -5,9 +5,12 @@ dependencies:
   config:
     - field.field.node.event.accountability_notes
     - field.field.node.event.body
+    - field.field.node.event.field_accordion
     - field.field.node.event.field_affiliated_personnel
     - field.field.node.event.field_audience
+    - field.field.node.event.field_basic_content
     - field.field.node.event.field_brand_pillars
+    - field.field.node.event.field_call_to_action
     - field.field.node.event.field_campus
     - field.field.node.event.field_contact_person
     - field.field.node.event.field_end_date
@@ -54,6 +57,15 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
+  field_accordion:
+    weight: 122
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
   field_affiliated_personnel:
     weight: 110
     label: above
@@ -70,6 +82,15 @@ content:
     third_party_settings: {  }
     type: entity_reference_label
     region: content
+  field_basic_content:
+    weight: 123
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
   field_brand_pillars:
     weight: 111
     label: above
@@ -77,6 +98,15 @@ content:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
+    region: content
+  field_call_to_action:
+    weight: 124
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
     region: content
   field_campus:
     weight: 121

--- a/config/sync/core.entity_view_display.node.general_info.default.yml
+++ b/config/sync/core.entity_view_display.node.general_info.default.yml
@@ -5,7 +5,10 @@ dependencies:
   config:
     - field.field.node.general_info.accountability_notes
     - field.field.node.general_info.body
+    - field.field.node.general_info.field_accordion
+    - field.field.node.general_info.field_basic_content
     - field.field.node.general_info.field_brand_pillars
+    - field.field.node.general_info.field_call_to_action
     - field.field.node.general_info.field_campus
     - field.field.node.general_info.field_featured_image
     - field.field.node.general_info.field_member_accountability
@@ -40,6 +43,24 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
+  field_accordion:
+    weight: 9
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
+  field_basic_content:
+    weight: 10
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
   field_brand_pillars:
     weight: 7
     label: above
@@ -47,6 +68,15 @@ content:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
+    region: content
+  field_call_to_action:
+    weight: 11
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
     region: content
   field_campus:
     weight: 8

--- a/config/sync/core.entity_view_display.node.landing_page.default.yml
+++ b/config/sync/core.entity_view_display.node.landing_page.default.yml
@@ -5,6 +5,9 @@ dependencies:
   config:
     - field.field.node.landing_page.accountability_notes
     - field.field.node.landing_page.body
+    - field.field.node.landing_page.field_accordion
+    - field.field.node.landing_page.field_basic_content
+    - field.field.node.landing_page.field_call_to_action
     - field.field.node.landing_page.field_contact_person
     - field.field.node.landing_page.field_featured_image
     - field.field.node.landing_page.field_member_accountability
@@ -13,6 +16,7 @@ dependencies:
     - field.field.node.landing_page.layout_builder__layout
     - node.type.landing_page
   module:
+    - entity_reference_revisions
     - layout_builder
     - layout_discovery
     - user
@@ -21,6 +25,63 @@ third_party_settings:
     allow_custom: true
     enabled: true
     sections:
+      -
+        layout_id: layout_onecol
+        layout_settings: {  }
+        components:
+          173d6ebb-01a7-4509-a7bb-09e596535eae:
+            uuid: 173d6ebb-01a7-4509-a7bb-09e596535eae
+            region: content
+            configuration:
+              id: 'field_block:node:landing_page:field_basic_content'
+              label: 'Basic Content'
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: entity_reference_revisions_entity_view
+                settings:
+                  view_mode: default
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+            additional: {  }
+            weight: 0
+          43c1c111-a4ea-45a7-bc0b-469dfdd57117:
+            uuid: 43c1c111-a4ea-45a7-bc0b-469dfdd57117
+            region: content
+            configuration:
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              id: 'field_block:node:landing_page:field_accordion'
+              formatter:
+                type: entity_reference_revisions_entity_view
+                label: above
+                settings:
+                  view_mode: default
+                  link: ''
+                third_party_settings: {  }
+            additional: {  }
+            weight: 1
+          bd31c08a-f305-4e45-ad3c-776b27bab871:
+            uuid: bd31c08a-f305-4e45-ad3c-776b27bab871
+            region: content
+            configuration:
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              id: 'field_block:node:landing_page:field_call_to_action'
+              formatter:
+                type: entity_reference_revisions_entity_view
+                label: above
+                settings:
+                  view_mode: default
+                  link: ''
+                third_party_settings: {  }
+            additional: {  }
+            weight: 2
+        third_party_settings: {  }
       -
         layout_id: layout_onecol
         layout_settings: {  }
@@ -72,6 +133,24 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
+  field_accordion:
+    type: entity_reference_revisions_entity_view
+    weight: 102
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_call_to_action:
+    type: entity_reference_revisions_entity_view
+    weight: 103
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
   field_featured_image:
     weight: 101
     label: above
@@ -88,6 +167,7 @@ content:
 hidden:
   accountability_notes: true
   body: true
+  field_basic_content: true
   field_contact_person: true
   field_member_accountability: true
   field_raci: true

--- a/config/sync/core.entity_view_display.node.program.default.yml
+++ b/config/sync/core.entity_view_display.node.program.default.yml
@@ -6,6 +6,9 @@ dependencies:
     - field.field.node.program.accountability_notes
     - field.field.node.program.admission_info
     - field.field.node.program.body
+    - field.field.node.program.field_accordion
+    - field.field.node.program.field_basic_content
+    - field.field.node.program.field_call_to_action
     - field.field.node.program.field_contact_person
     - field.field.node.program.field_location
     - field.field.node.program.field_member_accountability
@@ -30,6 +33,33 @@ content:
     weight: -20
     settings: {  }
     third_party_settings: {  }
+    region: content
+  field_accordion:
+    weight: 106
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
+  field_basic_content:
+    weight: 107
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
+  field_call_to_action:
+    weight: 108
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
     region: content
   field_organizational_parent:
     weight: 101

--- a/config/sync/core.entity_view_display.node.story.default.yml
+++ b/config/sync/core.entity_view_display.node.story.default.yml
@@ -4,8 +4,11 @@ status: true
 dependencies:
   config:
     - field.field.node.story.body
+    - field.field.node.story.field_accordion
     - field.field.node.story.field_accountability_notes
+    - field.field.node.story.field_basic_content
     - field.field.node.story.field_brand_pillars
+    - field.field.node.story.field_call_to_action
     - field.field.node.story.field_campus
     - field.field.node.story.field_date_published
     - field.field.node.story.field_featured
@@ -283,6 +286,57 @@ third_party_settings:
                 type: entity_reference_label
             additional: {  }
             weight: 15
+          595fcaf4-8367-4b38-a988-68b0c7b5d340:
+            uuid: 595fcaf4-8367-4b38-a988-68b0c7b5d340
+            region: content
+            configuration:
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              id: 'field_block:node:story:field_accordion'
+              formatter:
+                label: above
+                settings:
+                  view_mode: default
+                  link: ''
+                third_party_settings: {  }
+                type: entity_reference_revisions_entity_view
+            additional: {  }
+            weight: 16
+          8614f35a-d837-413c-abf4-bb6a8db4123b:
+            uuid: 8614f35a-d837-413c-abf4-bb6a8db4123b
+            region: content
+            configuration:
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              id: 'field_block:node:story:field_basic_content'
+              formatter:
+                label: above
+                settings:
+                  view_mode: default
+                  link: ''
+                third_party_settings: {  }
+                type: entity_reference_revisions_entity_view
+            additional: {  }
+            weight: 17
+          22cc94c5-4dc4-4eaa-bd56-97a63038eaf6:
+            uuid: 22cc94c5-4dc4-4eaa-bd56-97a63038eaf6
+            region: content
+            configuration:
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              id: 'field_block:node:story:field_call_to_action'
+              formatter:
+                label: above
+                settings:
+                  view_mode: default
+                  link: ''
+                third_party_settings: {  }
+                type: entity_reference_revisions_entity_view
+            additional: {  }
+            weight: 18
         third_party_settings: {  }
 id: node.story.default
 targetEntityType: node
@@ -301,12 +355,30 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
+  field_accordion:
+    weight: 15
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
   field_accountability_notes:
     weight: 12
     label: above
     settings: {  }
     third_party_settings: {  }
     type: basic_string
+    region: content
+  field_basic_content:
+    weight: 16
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
     region: content
   field_brand_pillars:
     weight: 13
@@ -315,6 +387,15 @@ content:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
+    region: content
+  field_call_to_action:
+    weight: 17
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
     region: content
   field_campus:
     weight: 8

--- a/config/sync/field.field.node.event.field_accordion.yml
+++ b/config/sync/field.field.node.event.field_accordion.yml
@@ -1,0 +1,61 @@
+uuid: 9224d544-6484-4d53-9a57-7c1b0c45fc3c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_accordion
+    - node.type.event
+    - paragraphs.paragraphs_type.accordion
+  module:
+    - entity_reference_revisions
+id: node.event.field_accordion
+field_name: field_accordion
+entity_type: node
+bundle: event
+label: Accordion
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      accordion: accordion
+    target_bundles_drag_drop:
+      accordion:
+        enabled: true
+        weight: 12
+      accordion_item:
+        weight: 13
+        enabled: false
+      basic_content:
+        weight: 14
+        enabled: false
+      call_to_action:
+        weight: 15
+        enabled: false
+      raci_consult:
+        weight: 16
+        enabled: false
+      raci_informed:
+        weight: 17
+        enabled: false
+      raci_responsible:
+        weight: 18
+        enabled: false
+      related_content:
+        weight: 19
+        enabled: false
+      related_media:
+        weight: 20
+        enabled: false
+      sample_course:
+        weight: 21
+        enabled: false
+      sample_courses:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.event.field_basic_content.yml
+++ b/config/sync/field.field.node.event.field_basic_content.yml
@@ -1,0 +1,61 @@
+uuid: 3adfcecf-629c-4060-b9e7-86fb654f8908
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_basic_content
+    - node.type.event
+    - paragraphs.paragraphs_type.basic_content
+  module:
+    - entity_reference_revisions
+id: node.event.field_basic_content
+field_name: field_basic_content
+entity_type: node
+bundle: event
+label: 'Basic Content'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      basic_content: basic_content
+    target_bundles_drag_drop:
+      accordion:
+        weight: 12
+        enabled: false
+      accordion_item:
+        weight: 13
+        enabled: false
+      basic_content:
+        enabled: true
+        weight: 14
+      call_to_action:
+        weight: 15
+        enabled: false
+      raci_consult:
+        weight: 16
+        enabled: false
+      raci_informed:
+        weight: 17
+        enabled: false
+      raci_responsible:
+        weight: 18
+        enabled: false
+      related_content:
+        weight: 19
+        enabled: false
+      related_media:
+        weight: 20
+        enabled: false
+      sample_course:
+        weight: 21
+        enabled: false
+      sample_courses:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.event.field_call_to_action.yml
+++ b/config/sync/field.field.node.event.field_call_to_action.yml
@@ -1,0 +1,61 @@
+uuid: 371ddb1f-ad6e-40df-b103-98e978e8ae9a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_call_to_action
+    - node.type.event
+    - paragraphs.paragraphs_type.call_to_action
+  module:
+    - entity_reference_revisions
+id: node.event.field_call_to_action
+field_name: field_call_to_action
+entity_type: node
+bundle: event
+label: 'Call To Action'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      call_to_action: call_to_action
+    target_bundles_drag_drop:
+      accordion:
+        weight: 12
+        enabled: false
+      accordion_item:
+        weight: 13
+        enabled: false
+      basic_content:
+        weight: 14
+        enabled: false
+      call_to_action:
+        enabled: true
+        weight: 15
+      raci_consult:
+        weight: 16
+        enabled: false
+      raci_informed:
+        weight: 17
+        enabled: false
+      raci_responsible:
+        weight: 18
+        enabled: false
+      related_content:
+        weight: 19
+        enabled: false
+      related_media:
+        weight: 20
+        enabled: false
+      sample_course:
+        weight: 21
+        enabled: false
+      sample_courses:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.general_info.field_accordion.yml
+++ b/config/sync/field.field.node.general_info.field_accordion.yml
@@ -1,0 +1,61 @@
+uuid: fe181010-78eb-448f-82a0-ac59c2dbc0bf
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_accordion
+    - node.type.general_info
+    - paragraphs.paragraphs_type.accordion
+  module:
+    - entity_reference_revisions
+id: node.general_info.field_accordion
+field_name: field_accordion
+entity_type: node
+bundle: general_info
+label: Accordion
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      accordion: accordion
+    target_bundles_drag_drop:
+      accordion:
+        enabled: true
+        weight: 12
+      accordion_item:
+        weight: 13
+        enabled: false
+      basic_content:
+        weight: 14
+        enabled: false
+      call_to_action:
+        weight: 15
+        enabled: false
+      raci_consult:
+        weight: 16
+        enabled: false
+      raci_informed:
+        weight: 17
+        enabled: false
+      raci_responsible:
+        weight: 18
+        enabled: false
+      related_content:
+        weight: 19
+        enabled: false
+      related_media:
+        weight: 20
+        enabled: false
+      sample_course:
+        weight: 21
+        enabled: false
+      sample_courses:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.general_info.field_basic_content.yml
+++ b/config/sync/field.field.node.general_info.field_basic_content.yml
@@ -1,0 +1,61 @@
+uuid: 3f5bd133-b44b-4491-9cdc-b70a225d765c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_basic_content
+    - node.type.general_info
+    - paragraphs.paragraphs_type.basic_content
+  module:
+    - entity_reference_revisions
+id: node.general_info.field_basic_content
+field_name: field_basic_content
+entity_type: node
+bundle: general_info
+label: 'Basic Content'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      basic_content: basic_content
+    target_bundles_drag_drop:
+      accordion:
+        weight: 12
+        enabled: false
+      accordion_item:
+        weight: 13
+        enabled: false
+      basic_content:
+        enabled: true
+        weight: 14
+      call_to_action:
+        weight: 15
+        enabled: false
+      raci_consult:
+        weight: 16
+        enabled: false
+      raci_informed:
+        weight: 17
+        enabled: false
+      raci_responsible:
+        weight: 18
+        enabled: false
+      related_content:
+        weight: 19
+        enabled: false
+      related_media:
+        weight: 20
+        enabled: false
+      sample_course:
+        weight: 21
+        enabled: false
+      sample_courses:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.general_info.field_call_to_action.yml
+++ b/config/sync/field.field.node.general_info.field_call_to_action.yml
@@ -1,0 +1,61 @@
+uuid: 3340615d-ce50-449f-be22-96d2d2b3e39f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_call_to_action
+    - node.type.general_info
+    - paragraphs.paragraphs_type.call_to_action
+  module:
+    - entity_reference_revisions
+id: node.general_info.field_call_to_action
+field_name: field_call_to_action
+entity_type: node
+bundle: general_info
+label: 'Call To Action'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      call_to_action: call_to_action
+    target_bundles_drag_drop:
+      accordion:
+        weight: 12
+        enabled: false
+      accordion_item:
+        weight: 13
+        enabled: false
+      basic_content:
+        weight: 14
+        enabled: false
+      call_to_action:
+        enabled: true
+        weight: 15
+      raci_consult:
+        weight: 16
+        enabled: false
+      raci_informed:
+        weight: 17
+        enabled: false
+      raci_responsible:
+        weight: 18
+        enabled: false
+      related_content:
+        weight: 19
+        enabled: false
+      related_media:
+        weight: 20
+        enabled: false
+      sample_course:
+        weight: 21
+        enabled: false
+      sample_courses:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.landing_page.field_accordion.yml
+++ b/config/sync/field.field.node.landing_page.field_accordion.yml
@@ -1,0 +1,61 @@
+uuid: 3e986166-edc5-4546-8b85-a923bf6edce5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_accordion
+    - node.type.landing_page
+    - paragraphs.paragraphs_type.accordion
+  module:
+    - entity_reference_revisions
+id: node.landing_page.field_accordion
+field_name: field_accordion
+entity_type: node
+bundle: landing_page
+label: Accordion
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      accordion: accordion
+    target_bundles_drag_drop:
+      accordion:
+        enabled: true
+        weight: 12
+      accordion_item:
+        weight: 13
+        enabled: false
+      basic_content:
+        weight: 14
+        enabled: false
+      call_to_action:
+        weight: 15
+        enabled: false
+      raci_consult:
+        weight: 16
+        enabled: false
+      raci_informed:
+        weight: 17
+        enabled: false
+      raci_responsible:
+        weight: 18
+        enabled: false
+      related_content:
+        weight: 19
+        enabled: false
+      related_media:
+        weight: 20
+        enabled: false
+      sample_course:
+        weight: 21
+        enabled: false
+      sample_courses:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.landing_page.field_basic_content.yml
+++ b/config/sync/field.field.node.landing_page.field_basic_content.yml
@@ -1,0 +1,61 @@
+uuid: bd1c8ce8-2e9a-4018-8ea0-eb3984fb225e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_basic_content
+    - node.type.landing_page
+    - paragraphs.paragraphs_type.basic_content
+  module:
+    - entity_reference_revisions
+id: node.landing_page.field_basic_content
+field_name: field_basic_content
+entity_type: node
+bundle: landing_page
+label: 'Basic Content'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      basic_content: basic_content
+    target_bundles_drag_drop:
+      accordion:
+        weight: 12
+        enabled: false
+      accordion_item:
+        weight: 13
+        enabled: false
+      basic_content:
+        enabled: true
+        weight: 14
+      call_to_action:
+        weight: 15
+        enabled: false
+      raci_consult:
+        weight: 16
+        enabled: false
+      raci_informed:
+        weight: 17
+        enabled: false
+      raci_responsible:
+        weight: 18
+        enabled: false
+      related_content:
+        weight: 19
+        enabled: false
+      related_media:
+        weight: 20
+        enabled: false
+      sample_course:
+        weight: 21
+        enabled: false
+      sample_courses:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.landing_page.field_call_to_action.yml
+++ b/config/sync/field.field.node.landing_page.field_call_to_action.yml
@@ -1,0 +1,61 @@
+uuid: 0731090d-8036-474d-9367-4b6eed9877ec
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_call_to_action
+    - node.type.landing_page
+    - paragraphs.paragraphs_type.call_to_action
+  module:
+    - entity_reference_revisions
+id: node.landing_page.field_call_to_action
+field_name: field_call_to_action
+entity_type: node
+bundle: landing_page
+label: 'Call To Action'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      call_to_action: call_to_action
+    target_bundles_drag_drop:
+      accordion:
+        weight: 12
+        enabled: false
+      accordion_item:
+        weight: 13
+        enabled: false
+      basic_content:
+        weight: 14
+        enabled: false
+      call_to_action:
+        enabled: true
+        weight: 15
+      raci_consult:
+        weight: 16
+        enabled: false
+      raci_informed:
+        weight: 17
+        enabled: false
+      raci_responsible:
+        weight: 18
+        enabled: false
+      related_content:
+        weight: 19
+        enabled: false
+      related_media:
+        weight: 20
+        enabled: false
+      sample_course:
+        weight: 21
+        enabled: false
+      sample_courses:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.program.field_accordion.yml
+++ b/config/sync/field.field.node.program.field_accordion.yml
@@ -1,0 +1,61 @@
+uuid: d333bd84-211d-4654-b3d1-ab09b8dd0509
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_accordion
+    - node.type.program
+    - paragraphs.paragraphs_type.accordion
+  module:
+    - entity_reference_revisions
+id: node.program.field_accordion
+field_name: field_accordion
+entity_type: node
+bundle: program
+label: Accordion
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      accordion: accordion
+    target_bundles_drag_drop:
+      accordion:
+        enabled: true
+        weight: 12
+      accordion_item:
+        weight: 13
+        enabled: false
+      basic_content:
+        weight: 14
+        enabled: false
+      call_to_action:
+        weight: 15
+        enabled: false
+      raci_consult:
+        weight: 16
+        enabled: false
+      raci_informed:
+        weight: 17
+        enabled: false
+      raci_responsible:
+        weight: 18
+        enabled: false
+      related_content:
+        weight: 19
+        enabled: false
+      related_media:
+        weight: 20
+        enabled: false
+      sample_course:
+        weight: 21
+        enabled: false
+      sample_courses:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.program.field_basic_content.yml
+++ b/config/sync/field.field.node.program.field_basic_content.yml
@@ -1,0 +1,61 @@
+uuid: df3a563e-8c49-4a56-83cc-1b4e83a760e9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_basic_content
+    - node.type.program
+    - paragraphs.paragraphs_type.basic_content
+  module:
+    - entity_reference_revisions
+id: node.program.field_basic_content
+field_name: field_basic_content
+entity_type: node
+bundle: program
+label: 'Basic Content'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      basic_content: basic_content
+    target_bundles_drag_drop:
+      accordion:
+        weight: 12
+        enabled: false
+      accordion_item:
+        weight: 13
+        enabled: false
+      basic_content:
+        enabled: true
+        weight: 14
+      call_to_action:
+        weight: 15
+        enabled: false
+      raci_consult:
+        weight: 16
+        enabled: false
+      raci_informed:
+        weight: 17
+        enabled: false
+      raci_responsible:
+        weight: 18
+        enabled: false
+      related_content:
+        weight: 19
+        enabled: false
+      related_media:
+        weight: 20
+        enabled: false
+      sample_course:
+        weight: 21
+        enabled: false
+      sample_courses:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.program.field_call_to_action.yml
+++ b/config/sync/field.field.node.program.field_call_to_action.yml
@@ -1,0 +1,61 @@
+uuid: d8c550b0-957c-4908-9991-8b45bbb0c7fb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_call_to_action
+    - node.type.program
+    - paragraphs.paragraphs_type.call_to_action
+  module:
+    - entity_reference_revisions
+id: node.program.field_call_to_action
+field_name: field_call_to_action
+entity_type: node
+bundle: program
+label: 'Call To Action'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      call_to_action: call_to_action
+    target_bundles_drag_drop:
+      accordion:
+        weight: 12
+        enabled: false
+      accordion_item:
+        weight: 13
+        enabled: false
+      basic_content:
+        weight: 14
+        enabled: false
+      call_to_action:
+        enabled: true
+        weight: 15
+      raci_consult:
+        weight: 16
+        enabled: false
+      raci_informed:
+        weight: 17
+        enabled: false
+      raci_responsible:
+        weight: 18
+        enabled: false
+      related_content:
+        weight: 19
+        enabled: false
+      related_media:
+        weight: 20
+        enabled: false
+      sample_course:
+        weight: 21
+        enabled: false
+      sample_courses:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.story.field_accordion.yml
+++ b/config/sync/field.field.node.story.field_accordion.yml
@@ -1,0 +1,61 @@
+uuid: b69ae640-b13b-47d7-aecb-f4c70dd0f0e4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_accordion
+    - node.type.story
+    - paragraphs.paragraphs_type.accordion
+  module:
+    - entity_reference_revisions
+id: node.story.field_accordion
+field_name: field_accordion
+entity_type: node
+bundle: story
+label: Accordion
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      accordion: accordion
+    target_bundles_drag_drop:
+      accordion:
+        enabled: true
+        weight: 12
+      accordion_item:
+        weight: 13
+        enabled: false
+      basic_content:
+        weight: 14
+        enabled: false
+      call_to_action:
+        weight: 15
+        enabled: false
+      raci_consult:
+        weight: 16
+        enabled: false
+      raci_informed:
+        weight: 17
+        enabled: false
+      raci_responsible:
+        weight: 18
+        enabled: false
+      related_content:
+        weight: 19
+        enabled: false
+      related_media:
+        weight: 20
+        enabled: false
+      sample_course:
+        weight: 21
+        enabled: false
+      sample_courses:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.story.field_basic_content.yml
+++ b/config/sync/field.field.node.story.field_basic_content.yml
@@ -1,0 +1,61 @@
+uuid: 67f00cb4-7123-4ffd-a148-fb803e6a98a8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_basic_content
+    - node.type.story
+    - paragraphs.paragraphs_type.basic_content
+  module:
+    - entity_reference_revisions
+id: node.story.field_basic_content
+field_name: field_basic_content
+entity_type: node
+bundle: story
+label: 'Basic Content'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      basic_content: basic_content
+    target_bundles_drag_drop:
+      accordion:
+        weight: 12
+        enabled: false
+      accordion_item:
+        weight: 13
+        enabled: false
+      basic_content:
+        enabled: true
+        weight: 14
+      call_to_action:
+        weight: 15
+        enabled: false
+      raci_consult:
+        weight: 16
+        enabled: false
+      raci_informed:
+        weight: 17
+        enabled: false
+      raci_responsible:
+        weight: 18
+        enabled: false
+      related_content:
+        weight: 19
+        enabled: false
+      related_media:
+        weight: 20
+        enabled: false
+      sample_course:
+        weight: 21
+        enabled: false
+      sample_courses:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.field.node.story.field_call_to_action.yml
+++ b/config/sync/field.field.node.story.field_call_to_action.yml
@@ -1,0 +1,61 @@
+uuid: 6ac01bd9-6b4d-48d1-910a-1302b4db0dcb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_call_to_action
+    - node.type.story
+    - paragraphs.paragraphs_type.call_to_action
+  module:
+    - entity_reference_revisions
+id: node.story.field_call_to_action
+field_name: field_call_to_action
+entity_type: node
+bundle: story
+label: 'Call To Action'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      call_to_action: call_to_action
+    target_bundles_drag_drop:
+      accordion:
+        weight: 12
+        enabled: false
+      accordion_item:
+        weight: 13
+        enabled: false
+      basic_content:
+        weight: 14
+        enabled: false
+      call_to_action:
+        enabled: true
+        weight: 15
+      raci_consult:
+        weight: 16
+        enabled: false
+      raci_informed:
+        weight: 17
+        enabled: false
+      raci_responsible:
+        weight: 18
+        enabled: false
+      related_content:
+        weight: 19
+        enabled: false
+      related_media:
+        weight: 20
+        enabled: false
+      sample_course:
+        weight: 21
+        enabled: false
+      sample_courses:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/sync/field.storage.node.field_accordion.yml
+++ b/config/sync/field.storage.node.field_accordion.yml
@@ -1,0 +1,21 @@
+uuid: cc54ed7e-2a83-4687-a5d7-e9596f6c1a37
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_accordion
+field_name: field_accordion
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_basic_content.yml
+++ b/config/sync/field.storage.node.field_basic_content.yml
@@ -1,0 +1,21 @@
+uuid: b5fd21fc-01a9-4b9d-a021-d84cd81f9bd6
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_basic_content
+field_name: field_basic_content
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_call_to_action.yml
+++ b/config/sync/field.storage.node.field_call_to_action.yml
@@ -1,0 +1,21 @@
+uuid: 83133cec-fd3b-4796-b1a1-5e2f4e9147cc
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_call_to_action
+field_name: field_call_to_action
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## Description
Post Training: Paragraphs Should be Accessible from All Content Types

## Affected URL

[Review here](http://pr-68-rooseveltedu.pantheonsite.io)

## Related Tickets

* [Post Training: Paragraphs Should be Accessible from All Content Types](https://kanopi.teamwork.com/#/tasks/26024042)


## Steps to Validate
1. Check each of the content types
1. See 3 new fields; Accordion, Basic Content, Call To Action

## Deploy Notes

_Import configurations_
